### PR TITLE
feat: add MCP progress notification support for long-running tools

### DIFF
--- a/src/browserServerBackend.ts
+++ b/src/browserServerBackend.ts
@@ -66,13 +66,13 @@ export class BrowserServerBackend implements ServerBackend {
     return this._tools.map(tool => toMcpTool(tool.schema));
   }
 
-  async callTool(name: string, rawArguments: mcpServer.CallToolRequest['params']['arguments']) {
+  async callTool(name: string, rawArguments: mcpServer.CallToolRequest['params']['arguments'], sendProgress?: mcpServer.ProgressCallback) {
     const tool = this._tools.find(tool => tool.schema.name === name)!;
     if (!tool)
       throw new Error(`Tool "${name}" not found`);
     const parsedArguments = tool.schema.inputSchema.parse(rawArguments || {});
     const context = this._context!;
-    const response = new Response(context, name, parsedArguments);
+    const response = new Response(context, name, parsedArguments, sendProgress);
     context.setRunningTool(true);
     try {
       await tool.handle(context, parsedArguments, response);

--- a/src/loopTools/main.ts
+++ b/src/loopTools/main.ts
@@ -53,7 +53,7 @@ class LoopToolsServerBackend implements ServerBackend {
     return this._tools.map(tool => toMcpTool(tool.schema));
   }
 
-  async callTool(name: string, args: mcpServer.CallToolRequest['params']['arguments']): Promise<mcpServer.CallToolResult> {
+  async callTool(name: string, args: mcpServer.CallToolRequest['params']['arguments'], _sendProgress?: mcpServer.ProgressCallback): Promise<mcpServer.CallToolResult> {
     const tool = this._tools.find(tool => tool.schema.name === name)!;
     const parsedArguments = tool.schema.inputSchema.parse(args || {});
     return await tool.handle(this._context!, parsedArguments);

--- a/src/mcp/proxyBackend.ts
+++ b/src/mcp/proxyBackend.ts
@@ -23,7 +23,7 @@ import { logUnhandledError } from '../utils/log.js';
 import { packageJSON } from '../utils/package.js';
 
 
-import type { ServerBackend, ClientVersion, Root } from './server.js';
+import type { ServerBackend, ClientVersion, Root, ProgressCallback } from './server.js';
 import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { Tool, CallToolResult, CallToolRequest } from '@modelcontextprotocol/sdk/types.js';
 
@@ -62,7 +62,7 @@ export class ProxyBackend implements ServerBackend {
     ];
   }
 
-  async callTool(name: string, args: CallToolRequest['params']['arguments'], _sendProgress?: any): Promise<CallToolResult> {
+  async callTool(name: string, args: CallToolRequest['params']['arguments'], _sendProgress?: ProgressCallback): Promise<CallToolResult> {
     if (name === this._contextSwitchTool.name)
       return this._callContextSwitchTool(args);
     return await this._currentClient!.callTool({

--- a/src/mcp/proxyBackend.ts
+++ b/src/mcp/proxyBackend.ts
@@ -62,7 +62,7 @@ export class ProxyBackend implements ServerBackend {
     ];
   }
 
-  async callTool(name: string, args: CallToolRequest['params']['arguments']): Promise<CallToolResult> {
+  async callTool(name: string, args: CallToolRequest['params']['arguments'], _sendProgress?: any): Promise<CallToolResult> {
     if (name === this._contextSwitchTool.name)
       return this._callContextSwitchTool(args);
     return await this._currentClient!.callTool({

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -28,6 +28,17 @@ export type { Tool, CallToolResult, CallToolRequest, Root } from '@modelcontextp
 const serverDebug = debug('pw:mcp:server');
 
 export type ClientVersion = { name: string, version: string };
+
+/**
+ * Callback for sending progress notifications to MCP clients.
+ *
+ * @param progress - Current progress value (0-based). For indeterminate progress, cycles through values.
+ * @param total - Optional total value. Omit for indeterminate progress, include for determinate.
+ *
+ * Usage:
+ * - Determinate: sendProgress(50, 100) indicates 50% complete
+ * - Indeterminate: sendProgress(n) without total indicates unknown completion
+ */
 export type ProgressCallback = (progress: number, total?: number) => Promise<void>;
 export interface ServerBackend {
   name: string;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -74,14 +74,19 @@ export function createServer(backend: ServerBackend, runHeartbeat: boolean): Ser
     // Create progress callback if client requested progress notifications
     const progressToken = request.params._meta?.progressToken;
     const sendProgress = progressToken ? async (progress: number, total?: number) => {
-      await extra.sendNotification({
-        method: 'notifications/progress',
-        params: {
-          progressToken,
-          progress,
-          total,
-        },
-      });
+      try {
+        await extra.sendNotification({
+          method: 'notifications/progress',
+          params: {
+            progressToken,
+            progress,
+            total,
+          },
+        });
+      } catch (error) {
+        // Log but don't fail the tool if progress notification fails
+        serverDebug('Progress notification failed:', error);
+      }
     } : undefined;
 
     try {

--- a/src/response.ts
+++ b/src/response.ts
@@ -28,15 +28,17 @@ export class Response {
   private _includeSnapshot = false;
   private _includeTabs = false;
   private _tabSnapshot: TabSnapshot | undefined;
+  private _sendProgress?: (progress: number, total?: number) => Promise<void>;
 
   readonly toolName: string;
   readonly toolArgs: Record<string, any>;
   private _isError: boolean | undefined;
 
-  constructor(context: Context, toolName: string, toolArgs: Record<string, any>) {
+  constructor(context: Context, toolName: string, toolArgs: Record<string, any>, sendProgress?: (progress: number, total?: number) => Promise<void>) {
     this._context = context;
     this.toolName = toolName;
     this.toolArgs = toolArgs;
+    this._sendProgress = sendProgress;
   }
 
   addResult(result: string) {
@@ -78,6 +80,11 @@ export class Response {
 
   setIncludeTabs() {
     this._includeTabs = true;
+  }
+
+  async sendProgress(progress: number, total?: number) {
+    if (this._sendProgress)
+      await this._sendProgress(progress, total);
   }
 
   async finish() {

--- a/src/response.ts
+++ b/src/response.ts
@@ -82,6 +82,11 @@ export class Response {
     this._includeTabs = true;
   }
 
+  /**
+   * Send a progress notification to the MCP client if progress tracking is enabled.
+   * @param progress - Current progress value
+   * @param total - Optional total value. Omit for indeterminate progress.
+   */
   async sendProgress(progress: number, total?: number) {
     if (this._sendProgress)
       await this._sendProgress(progress, total);

--- a/src/tools/install.ts
+++ b/src/tools/install.ts
@@ -22,7 +22,8 @@ import { defineTool } from './tool.js';
 
 
 // Progress notification constants
-const PROGRESS_UPDATE_INTERVAL_MS = 5000;
+const PROGRESS_UPDATE_INTERVAL_MS = 5000; // Send progress update every 5 seconds
+const INDETERMINATE_PROGRESS_MAX = 100; // Maximum value for cycling progress indicator
 
 const install = defineTool({
   capability: 'core-install',
@@ -44,9 +45,10 @@ const install = defineTool({
     const output: string[] = [];
 
     // Send periodic progress notifications (indeterminate progress)
+    // Progress cycles from 0 to INDETERMINATE_PROGRESS_MAX-1 to show activity
     let progressValue = 0;
     const progressInterval = setInterval(async () => {
-      progressValue = (progressValue + 1) % 100;
+      progressValue = (progressValue + 1) % INDETERMINATE_PROGRESS_MAX;
       await response.sendProgress(progressValue); // Send without total for indeterminate
     }, PROGRESS_UPDATE_INTERVAL_MS);
 

--- a/tests/install.spec.ts
+++ b/tests/install.spec.ts
@@ -27,14 +27,14 @@ test('browser_install', async ({ client, mcpBrowser }) => {
 
 test('browser_install with progress notifications', async ({ client, mcpBrowser }) => {
   test.skip(mcpBrowser !== 'chromium', 'Test only chromium');
-  
+
   // Track progress notifications if we had a way to intercept them
   // For now, just verify the tool completes successfully with progress token
   const result = await client.callTool({
     name: 'browser_install',
     _meta: { progressToken: 'test-progress-token' }
   });
-  
+
   // Verify the tool completes successfully
   expect(result).toHaveProperty('content');
   expect(result.isError).not.toBe(true);
@@ -42,12 +42,12 @@ test('browser_install with progress notifications', async ({ client, mcpBrowser 
 
 test('browser_install without progress token', async ({ client, mcpBrowser }) => {
   test.skip(mcpBrowser !== 'chromium', 'Test only chromium');
-  
+
   // Verify tool works without progress token (backward compatibility)
   const result = await client.callTool({
     name: 'browser_install',
   });
-  
+
   expect(result).toHaveProperty('content');
   expect(result.isError).not.toBe(true);
 });

--- a/tests/install.spec.ts
+++ b/tests/install.spec.ts
@@ -24,3 +24,30 @@ test('browser_install', async ({ client, mcpBrowser }) => {
     tabs: expect.stringContaining(`No open tabs`),
   });
 });
+
+test('browser_install with progress notifications', async ({ client, mcpBrowser }) => {
+  test.skip(mcpBrowser !== 'chromium', 'Test only chromium');
+  
+  // Track progress notifications if we had a way to intercept them
+  // For now, just verify the tool completes successfully with progress token
+  const result = await client.callTool({
+    name: 'browser_install',
+    _meta: { progressToken: 'test-progress-token' }
+  });
+  
+  // Verify the tool completes successfully
+  expect(result).toHaveProperty('content');
+  expect(result.isError).not.toBe(true);
+});
+
+test('browser_install without progress token', async ({ client, mcpBrowser }) => {
+  test.skip(mcpBrowser !== 'chromium', 'Test only chromium');
+  
+  // Verify tool works without progress token (backward compatibility)
+  const result = await client.callTool({
+    name: 'browser_install',
+  });
+  
+  expect(result).toHaveProperty('content');
+  expect(result.isError).not.toBe(true);
+});


### PR DESCRIPTION
- Add progress notification support to ServerBackend interface
- Pass progress callback from MCP request handler to tool implementations
- Update Response class to send progress notifications to clients
- Implement periodic progress updates in browser_install tool
- Update all ServerBackend implementations to support optional progress callback

This allows MCP clients to receive progress updates during long-running operations like browser installation, preventing timeouts and improving user experience.